### PR TITLE
ansible-ci-module の追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: "gitsubmodule"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    time: "02:00"
+    timezone: "Asia/Tokyo"
+  reviewers:
+    - "y-hashida"

--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
+      fail-fast: False
     steps:
       - name: Install LXD and CI tools
         run: |

--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -1,0 +1,59 @@
+name: ansible ci
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - v*
+
+jobs:
+  create-matrix:
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Install pip3 and tox
+        run: |
+          sudo apt update
+          sudo apt -y install python3 python3-pip python3-setuptools
+          sudo pip3 install tox
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Create tox env list
+        id: set-matrix
+        run: |
+          TOX_ENV=$(python3 ansible-ci-module/scripts/toxenv_to_json.py)
+          echo "::set-output name=matrix::{\"tox_env\":[${TOX_ENV}]}"
+
+  ansible-ci:
+    needs: create-matrix
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
+    steps:
+      - name: Install LXD and CI tools
+        run: |
+          sudo apt update
+          sudo apt install lxd lxd-tools qemu-block-extra python3 python3-pip python3-setuptools
+
+      - name: Configure LXD
+        run: |
+          sudo lxd init --auto
+
+      - name: Install tox using python3-pip
+        run: |
+          sudo pip3 install tox
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: ansible-ci
+        run: |
+          sudo tox -e ${{ matrix.tox_env }} -c ansible-ci-module/tox.ini

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ansible-ci-module"]
+	path = ansible-ci-module
+	url = https://github.com/link-u/ansible-ci-module.git

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,7 @@ nginx_virtual_host_config_backup: no      # on or off : conf ファイルを変�
 nginx_default_ip_white_list:              # nginx にアクセスできるデフォルト IP アドレスホワイトリスト
   - "127.0.0.1"
 ## Virtual host を設定する変数
-nginx_vhosts: []                          # 初期値は空の配列
+nginx_vhosts:
+  - conf_file_name: "localhost.conf"
 nginx_external_src_conf_dir: >-           # 予め用意した vhost の conf ファイルを管理する src ディレクトリ
   {{ playbook_dir }}/../files/nginx/conf.d

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -17,11 +17,17 @@
   file:
     path: /etc/nginx/conf.d/
     state: directory
+    owner: "root"
+    group: "root"
+    mode: "0755"
 
 - name: Ensure extra directories are present
   file:
     path: "{{ item }}"
     state: directory
+    owner: "root"
+    group: "root"
+    mode: "0755"
   loop: "{{ nginx_extra_directories }}"
 
 - name: Set nginx config
@@ -86,6 +92,9 @@
   copy:
     src: "{{ nginx_ssl_src_base_dir }}/{{ item.ssl.src_dir_name | default(item.conf_file_name) }}/"
     dest: "{{ item.ssl.dest_dir | default('/etc/nginx/ssl/') }}"
+    owner: "root"
+    group: "root"
+    mode: "0755"
   when:
     - item.ssl | default(false)
     - item.ssl.put_ssl_keys | default(true)

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -54,7 +54,7 @@
   tags: vhost
 
 - name: Check virtual_host config files
-  shell: ls -v /etc/nginx/conf.d | grep -E '.conf$'
+  command: bash -c "set -o pipefail && ls -v /etc/nginx/conf.d | grep -E '.conf$'"
   register: _nginx_conf_files
   changed_when: False
   check_mode: no

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,5 +38,4 @@
   apt:
     pkg: python3-passlib
     update_cache: yes
-    cache_valid_time: 86400
     state: present

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,6 +2,12 @@
 # tasks/install.yml (nginx)
 # Prefix : nginx
 
+- name: Pre-install packages
+  apt:
+    name: "gpg"
+    state: present
+    update_cache: yes
+
 - name: Trust our package maintainers.
   apt_key:
     id: 4DE76DC836A27DBAE17FAC4B09C9B9C18F429AAE


### PR DESCRIPTION
### 変更点

* ansible-ci-module の追加
* このプルリクでできる CI について
  * ansible-lint による linting
  * molecule による各環境ごとのインストールテスト

* このプルリクではまだ未実装の CI について
  * testinfra による verify
    ※ これは別のプルリクで実装する予定.
