### PR TITLE
protobufをgzip圧縮するようにした

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -35,10 +35,12 @@ http {
 
     access_log {{ nginx_access_log }};
 
+    # TODO:　どれをどっちで圧縮する方が良いのかはマシンの計算能力に依存するので、
+    #        選べるようになっているとベスト
     gzip on;
     gzip_min_length 1024;
     gzip_comp_level 6;
-    gzip_types text/plain text/css application/json application/x-javascript text/javascript application/javascript;
+    gzip_types text/plain text/css application/json application/x-javascript text/javascript application/javascript application/protobuf application/x-protobuf;
 
     brotli on;
     brotli_types text/css text/javascript application/javascript;


### PR DESCRIPTION
brotliは流石に結構重いなぁと思ってデフォルトではgzipだけで圧縮することにしました。弱めの仮想マシンでbrotliでProtoBufを圧縮するのはちょっとこわい。

本当は変数とか使って定義できればいいかな？

mime typeに関しては次を踏襲：
https://stackoverflow.com/questions/1425912/google-protocol-buffers-and-http