### PR TITLE
予め用意した vhost 用の conf ファイルをデプロイできるようにした.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,3 +51,5 @@ nginx_default_ip_white_list:              # nginx にアクセスできるデフ
   - "127.0.0.1"
 ## Virtual host を設定する変数
 nginx_vhosts: []                          # 初期値は空の配列
+nginx_external_src_conf_dir: >-           # 予め用意した vhost の conf ファイルを管理する src ディレクトリ
+  {{ playbook_dir }}/../files/nginx/conf.d

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -44,7 +44,7 @@
 
 - name: Set virtual_host config from external conf file
   template:
-    src: "{{ item.external_conf_dir }}/{{ item.conf_file_name }}"
+    src: "{{ nginx_external_src_conf_dir }}/{{ item.conf_file_name }}"
     dest: /etc/nginx/conf.d/{{ item.conf_file_name }}
     mode: "0644"
     backup: "{{ nginx_virtual_host_config_backup }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -37,6 +37,18 @@
     dest: /etc/nginx/conf.d/{{ item.conf_file_name }}
     mode: "0644"
     backup: "{{ nginx_virtual_host_config_backup }}"
+  when: not ( item.use_external_conf | default(False) )
+  loop: "{{ nginx_vhosts }}"
+  notify: Reload nginx
+  tags: vhost
+
+- name: Set virtual_host config from external conf file
+  template:
+    src: "{{ item.external_conf_dir }}/{{ item.conf_file_name }}"
+    dest: /etc/nginx/conf.d/{{ item.conf_file_name }}
+    mode: "0644"
+    backup: "{{ nginx_virtual_host_config_backup }}"
+  when: item.use_external_conf | default(False)
   loop: "{{ nginx_vhosts }}"
   notify: Reload nginx
   tags: vhost


### PR DESCRIPTION
### 変更点

予め用意した vhost 用の conf ファイルをデプロイできるようにしました.
これにより, 

* 自動化に向いているのは従来版の書き方
* 簡単に nginx サーバを構築したい場合は今回の書き方

といった使い分けが可能になります.

ansible 実行元で, `nginx_external_src_conf_dir` に定義したディレクトリのパスに保存された conf ファイルをデプロイ出来ます.
デプロイできるファイルは 変数 `nginx_vhosts` に定義されてあるもののみとなります.
したがって, `nginx_vhosts` はどちらの書き方でもイジる必要があります.

また, group_vars での `nginx_vhosts` の書き方例を以下に記します (従来の書き方と今回の書き方の比較)

```yaml
## サンプル用の vhost (こちらは従来の書き方)
_all_nginx_vhost_sample_conf_vars:
  conf_file_name: "sample.conf"
  listen_list: ["80"]
  root: "/var/www/sample"
  serer_name: "localhost"
  index: "index.html index.php"
  access_log: /var/log/nginx/sample-access.log ltsv
  locations:
    - location: "~ \\.php$"
      value: |
        include fastcgi_params;
        fastcgi_index index.php;
        fastcgi_pass unix:/run/php/php{{ php7_version }}-fpm.sock;
        fastcgi_param SCRIPT_FILENAME  $document_root$fastcgi_script_name;
        fastcgi_hide_header "X-APP-INFO";
  extra_parameters_str: |
    try_files $uri $uri/ @rewrite;


## 予め用意した vhost の conf ファイルを使う場合 (今回の書き方)
#   * sample2.conf は予め用意してあるファイル
_all_nginx_vhost_sample2_conf_vars:
  conf_file_name: "sample2.conf"
  use_external_conf: yes

## 全 vhost のリスト化
nginx_vhosts:
  - "{{ _nginx_vhost_sample_conf_vars }}"
  - "{{ _nginx_vhost_sample2_conf_vars }}"
```

例を見て分かるように, `nginx_vhosts[n].use_external_conf: yes` のときは今回の機能を使うようになります (デフォルトでは no)
