### PR TITLE
VTS moduleを有効にした

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -59,16 +59,22 @@ http {
 
     include /etc/nginx/conf.d/*.conf;
 
-    # show connection status by stub_status
+    vhost_traffic_status_zone;
     server {
-        listen 10058;
+        listen 127.0.0.1:10058;
+        listen     [::1]:10058;
         server_name nginx_status;
 
+        # show connection status by stub_status
         location /nginx_status {
             stub_status on;
             access_log off;
-            allow 127.0.0.1;
-            deny all;
+        }
+        # show connection status by nginx_vts_status
+        location /nginx_vts_status {
+            vhost_traffic_status_display;
+            vhost_traffic_status_display_format html;
+            access_log off;
         }
     }
 


### PR DESCRIPTION
最近（といってももう２週ぐらい前だけど）ビルドしたnginx 1.19.2で[nginx vts module](https://github.com/vozlt/nginx-module-vts)を有効にしました。

これを使うと、今Zabbixから監視しているよりももっと細かいデータがたくさん取れるようになるのですが、それを有効にするためには設定ファイルの更新が必要になります。

このプルリクでは、実際にその設定を有効にしました。

ついでとして、今全世界に対してlistenした上でlocalhost以外からの接続を拒否しているんですが、listenする先をそもそもlocalhostだけにしました。実用的な意味はあんまりないんですが、おまじない程度にはちょこっとだけセキュリティも向上する…かも？