### PR TITLE
Feature/optionalize strict transport security

### DIFF
--- a/templates/_ssl.conf.j2
+++ b/templates/_ssl.conf.j2
@@ -23,7 +23,9 @@
     ssl_ecdh_curve {{ vhost_ssl.ecdh_curve }};
 {% endif %}
     ssl_session_cache {{ vhost_ssl.session_cache }};
-    add_header Strict-Transport-Security 'max-age=31536000;';
+{% if vhost_ssl.stt %}
+    add_header Strict-Transport-Security 'max-age={{ vhost_ssl.stt.max_age }}; {{ vhost_ssl.stt.option | default('') }}';
+{% endif %}
 
 {% if vhost_ssl.ocsp_stapling | default(off) %}
     ssl_stapling on;

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -75,3 +75,5 @@ nginx_vhost_base_settings_for_ssl:
   put_ssl_keys: yes
   ocsp_stapling: off
   http_redirect: on
+  stt:
+    max_age: 31536000


### PR DESCRIPTION
がうがうで `Strict-Transport-Security` の設定を消したいというお話があったので、デフォルト値を追記した上で各プロジェクトの group_vars で上書きできるようにしました。
値の設定例的な markdown が見つけられなかったのでそこには手を加えていませんが、ありましたら教えてください。編集します。